### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to icon-only Add to Cart buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Add to Cart Button Accessibility
+**Learning:** Icon-only buttons in product cards often lack screen reader support and visible tooltips, reducing accessibility and clarity. Adding `aria-label` and `title` attributes immediately improves UX without breaking the existing layout.
+**Action:** Always check icon-only buttons for `aria-label` and `title` attributes across the application.

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Star, ShoppingCart } from 'lucide-react';
 import { Product } from '../types';
 import { useApp } from '../context/AppContext';
+import { translations } from '../utils/translations';
 
 interface ProductCardProps {
   product: Product;
@@ -11,6 +12,7 @@ interface ProductCardProps {
 
 export const ProductCard: React.FC<ProductCardProps> = ({ product, view = 'grid' }) => {
   const { language, addToCart } = useApp();
+  const t = translations[language];
 
   const handleAddToCart = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -66,6 +68,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, view = 'grid'
               className="flex items-center space-x-2 rtl:space-x-reverse px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
             >
               <ShoppingCart className="w-4 h-4" />
+              <span>{t.product.addToCart}</span>
             </button>
           </div>
         </div>
@@ -122,6 +125,8 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, view = 'grid'
           <button
             onClick={handleAddToCart}
             className="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+            aria-label={t.product.addToCart}
+            title={t.product.addToCart}
           >
             <ShoppingCart className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What: Added accessible text and tooltips to the "Add to Cart" buttons in `ProductCard.tsx` based on translation keys. Added missing text to list view and ARIA labels/tooltips to grid view.
🎯 Why: Icon-only buttons without `aria-label` or `title` attributes are completely opaque to screen readers and lack helpful hover contexts for pointer users.
♿ Accessibility: Ensures that users relying on assistive technology hear an accurate description of the button's action.

---
*PR created automatically by Jules for task [2696077213771133277](https://jules.google.com/task/2696077213771133277) started by @AbdalrahmanAmr*